### PR TITLE
Document self-serve Docker and Python API options

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,17 +1,11 @@
 import HeroSection from '@/components/HeroSection';
-import AuthSection from '@/components/AuthSection';
-import RequestSection from '@/components/RequestSection';
-import HouseholdSection from '@/components/HouseholdSection';
-import ModelLink from '@/components/ModelLink';
+import ApiDocsContent from '@/components/ApiDocsContent';
 
 export default function HomePage() {
   return (
     <main>
       <HeroSection />
-      <AuthSection />
-      <RequestSection />
-      <HouseholdSection />
-      <ModelLink />
+      <ApiDocsContent />
     </main>
   );
 }

--- a/src/components/AccessModeSelector.jsx
+++ b/src/components/AccessModeSelector.jsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { ACCESS_MODE_OPTIONS } from './accessModes';
+
+export default function AccessModeSelector({ accessMode, onChange }) {
+  const selectedMode =
+    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
+
+  return (
+    <section className="sticky top-4 z-30 px-6 -mt-8 md:-mt-10 mb-10">
+      <div className="max-w-4xl mx-auto rounded-2xl border border-border-light bg-white/95 shadow-[0_12px_32px_rgba(15,23,42,0.08)] backdrop-blur">
+        <div className="px-5 py-4 md:px-6 md:py-5">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="max-w-xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary-700 mb-2">
+                Access path
+              </p>
+              <h2 className="text-lg font-semibold text-text-primary">
+                Choose one path and the examples below stay in sync.
+              </h2>
+              <p className="text-sm text-text-secondary mt-1">{selectedMode.description}</p>
+            </div>
+
+            <div
+              className="inline-flex flex-wrap rounded-xl border border-border-light bg-gray-50 p-1 gap-1"
+              role="tablist"
+              aria-label="Access path selector"
+            >
+              {ACCESS_MODE_OPTIONS.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={accessMode === option.id}
+                  onClick={() => onChange(option.id)}
+                  className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    accessMode === option.id
+                      ? 'bg-primary-600 text-white'
+                      : 'text-text-secondary hover:bg-gray-100'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/AccessModeSelector.jsx
+++ b/src/components/AccessModeSelector.jsx
@@ -1,10 +1,33 @@
 'use client';
 
-import { ACCESS_MODE_OPTIONS } from './accessModes';
+import { useId, useRef } from 'react';
+import { ACCESS_MODE_OPTIONS, getAccessModeOption } from './accessModes';
 
 export default function AccessModeSelector({ accessMode, onChange }) {
-  const selectedMode =
-    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
+  const selectedMode = getAccessModeOption(accessMode);
+  const selectorLabelId = useId();
+  const optionRefs = useRef([]);
+
+  function moveFocus(nextIndex) {
+    const option = ACCESS_MODE_OPTIONS[nextIndex];
+    if (!option) {
+      return;
+    }
+
+    onChange(option.id);
+    optionRefs.current[nextIndex]?.focus();
+  }
+
+  function handleKeyDown(event, index) {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft' && event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      return;
+    }
+
+    event.preventDefault();
+    const delta = event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 : -1;
+    const nextIndex = (index + delta + ACCESS_MODE_OPTIONS.length) % ACCESS_MODE_OPTIONS.length;
+    moveFocus(nextIndex);
+  }
 
   return (
     <section className="sticky top-4 z-30 px-6 -mt-8 md:-mt-10 mb-10">
@@ -12,7 +35,10 @@ export default function AccessModeSelector({ accessMode, onChange }) {
         <div className="px-5 py-4 md:px-6 md:py-5">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="max-w-xl">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary-700 mb-2">
+              <p
+                id={selectorLabelId}
+                className="text-xs font-semibold uppercase tracking-[0.18em] text-primary-700 mb-2"
+              >
                 Access path
               </p>
               <h2 className="text-lg font-semibold text-text-primary">
@@ -23,16 +49,21 @@ export default function AccessModeSelector({ accessMode, onChange }) {
 
             <div
               className="inline-flex flex-wrap rounded-xl border border-border-light bg-gray-50 p-1 gap-1"
-              role="tablist"
-              aria-label="Access path selector"
+              role="radiogroup"
+              aria-labelledby={selectorLabelId}
             >
-              {ACCESS_MODE_OPTIONS.map((option) => (
+              {ACCESS_MODE_OPTIONS.map((option, index) => (
                 <button
                   key={option.id}
                   type="button"
-                  role="tab"
-                  aria-selected={accessMode === option.id}
+                  ref={(node) => {
+                    optionRefs.current[index] = node;
+                  }}
+                  role="radio"
+                  aria-checked={accessMode === option.id}
+                  tabIndex={accessMode === option.id ? 0 : -1}
                   onClick={() => onChange(option.id)}
+                  onKeyDown={(event) => handleKeyDown(event, index)}
                   className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                     accessMode === option.id
                       ? 'bg-primary-600 text-white'

--- a/src/components/ApiDocsContent.jsx
+++ b/src/components/ApiDocsContent.jsx
@@ -5,7 +5,7 @@ import AccessModeSelector from './AccessModeSelector';
 import AuthSection from './AuthSection';
 import RequestSection from './RequestSection';
 import HouseholdSection from './HouseholdSection';
-import VariableExplorer from './VariableExplorer';
+import ModelLink from './ModelLink';
 
 export default function ApiDocsContent() {
   const [accessMode, setAccessMode] = useState('rest');
@@ -16,7 +16,7 @@ export default function ApiDocsContent() {
       <AuthSection accessMode={accessMode} />
       <RequestSection accessMode={accessMode} />
       <HouseholdSection accessMode={accessMode} />
-      <VariableExplorer />
+      <ModelLink />
     </>
   );
 }

--- a/src/components/ApiDocsContent.jsx
+++ b/src/components/ApiDocsContent.jsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useState } from 'react';
+import AccessModeSelector from './AccessModeSelector';
+import AuthSection from './AuthSection';
+import RequestSection from './RequestSection';
+import HouseholdSection from './HouseholdSection';
+import VariableExplorer from './VariableExplorer';
+
+export default function ApiDocsContent() {
+  const [accessMode, setAccessMode] = useState('rest');
+
+  return (
+    <>
+      <AccessModeSelector accessMode={accessMode} onChange={setAccessMode} />
+      <AuthSection accessMode={accessMode} />
+      <RequestSection accessMode={accessMode} />
+      <HouseholdSection accessMode={accessMode} />
+      <VariableExplorer />
+    </>
+  );
+}

--- a/src/components/AuthSection.jsx
+++ b/src/components/AuthSection.jsx
@@ -3,6 +3,13 @@
 import CodeBlock from './CodeBlock';
 import { IconLock, IconKey, IconShield } from '@tabler/icons-react';
 
+const dockerExample = `docker pull ghcr.io/policyengine/policyengine-household-api:latest
+docker run --rm -p 8080:8080 ghcr.io/policyengine/policyengine-household-api:latest`;
+
+const pythonModelExample = `pip install policyengine-us`;
+
+const pythonToolkitExample = `pip install "policyengine[us]"`;
+
 const curlExample = `curl --request POST \\
   --url https://policyengine.uk.auth0.com/oauth/token \\
   --header 'Content-Type: application/json' \\
@@ -38,47 +45,111 @@ export default function AuthSection() {
       <div className="max-w-4xl mx-auto px-6">
         <h2 className="text-3xl font-bold text-text-primary mb-6">Getting started</h2>
         <p className="text-text-secondary mb-8 text-lg">
-          The PolicyEngine household API uses OAuth 2.0 client credentials for authentication.
-          Access is not public &mdash; contact{' '}
-          <a href="mailto:hello@policyengine.org" className="text-primary-600 hover:text-primary-700 underline">
-            hello@policyengine.org
-          </a>{' '}
-          to request API credentials.
+          You can use PolicyEngine three ways: our hosted API, the public household API Docker image,
+          or our Python packages. If you want to start immediately, use Docker or Python. If you want
+          a managed hosted endpoint, request API credentials.
         </p>
 
         <div className="grid md:grid-cols-3 gap-4 mb-12">
           <div className="p-4 rounded-lg border border-border-light bg-white">
             <div className="flex items-center gap-3 mb-2">
               <IconKey size={20} className="text-primary-600" />
-              <span className="font-semibold text-sm">1. Get credentials</span>
+              <span className="font-semibold text-sm">Hosted API</span>
             </div>
             <p className="text-sm text-text-secondary">
-              PolicyEngine provides a Client ID and Client Secret. These don&apos;t expire. Keep them private.
+              Use our managed endpoint with OAuth credentials issued by PolicyEngine.
             </p>
           </div>
           <div className="p-4 rounded-lg border border-border-light bg-white">
             <div className="flex items-center gap-3 mb-2">
               <IconLock size={20} className="text-primary-600" />
-              <span className="font-semibold text-sm">2. Fetch a token</span>
+              <span className="font-semibold text-sm">Docker image</span>
             </div>
             <p className="text-sm text-text-secondary">
-              Exchange credentials for a Bearer token (valid ~30 days, max 100 requests/month for tokens).
+              Run the same household API yourself via GitHub Container Registry, without waiting for credentials.
             </p>
           </div>
           <div className="p-4 rounded-lg border border-border-light bg-white">
             <div className="flex items-center gap-3 mb-2">
               <IconShield size={20} className="text-primary-600" />
-              <span className="font-semibold text-sm">3. Make requests</span>
+              <span className="font-semibold text-sm">Python packages</span>
             </div>
             <p className="text-sm text-text-secondary">
-              Include the Bearer token in the Authorization header of every API call.
+              Call the US model directly from Python if you do not need an HTTP layer.
             </p>
           </div>
         </div>
 
-        <h3 className="text-2xl font-semibold text-text-primary mb-4" id="authentication">Authentication</h3>
+        <h3 className="text-2xl font-semibold text-text-primary mb-4">Self-serve without waiting</h3>
+        <p className="text-text-secondary mb-6">
+          These public options do not require an API key request.
+        </p>
+
+        <div className="grid md:grid-cols-2 gap-6 mb-6">
+          <div className="p-5 rounded-lg border border-border-light bg-primary-50">
+            <h4 className="text-lg font-semibold text-text-primary mb-3">Public Docker image</h4>
+            <p className="text-text-secondary mb-3">
+              Run the household API locally or on your own infrastructure using the public container
+              image. The image uses the same REST interface as the hosted API, so you can send the
+              same request body to <code className="bg-white px-1.5 py-0.5 rounded text-sm">http://localhost:8080/us/calculate</code>.
+            </p>
+            <p className="text-sm text-text-secondary">
+              <a
+                href="https://github.com/PolicyEngine/policyengine-household-api/pkgs/container/policyengine-household-api"
+                className="text-primary-600 hover:text-primary-700 underline"
+              >
+                GitHub Container Registry
+              </a>{' '}
+              {' '}·{' '}
+              <a
+                href="https://github.com/PolicyEngine/policyengine-household-api/blob/main/config/README.md"
+                className="text-primary-600 hover:text-primary-700 underline"
+              >
+                configuration docs
+              </a>
+            </p>
+          </div>
+
+          <div className="p-5 rounded-lg border border-border-light bg-white">
+            <h4 className="text-lg font-semibold text-text-primary mb-3">Python packages</h4>
+            <p className="text-text-secondary mb-3">
+              Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine-us</code> for
+              direct access to the US model in Python 3.11+, or <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine[us]</code>{' '}
+              for the higher-level analysis toolkit in Python 3.13+.
+            </p>
+            <p className="text-sm text-text-secondary">
+              <a
+                href="https://github.com/PolicyEngine/policyengine-us"
+                className="text-primary-600 hover:text-primary-700 underline"
+              >
+                policyengine-us
+              </a>{' '}
+              {' '}·{' '}
+              <a
+                href="https://github.com/PolicyEngine/policyengine.py"
+                className="text-primary-600 hover:text-primary-700 underline"
+              >
+                policyengine.py
+              </a>
+            </p>
+          </div>
+        </div>
+
+        <CodeBlock code={dockerExample} language="bash" title="Docker (same HTTP API, self-hosted)" />
+
+        <div className="grid md:grid-cols-2 gap-6 mb-12">
+          <CodeBlock code={pythonModelExample} language="bash" title="Direct US model (Python 3.11+)" />
+          <CodeBlock code={pythonToolkitExample} language="bash" title="Higher-level toolkit (Python 3.13+)" />
+        </div>
+
+        <h3 className="text-2xl font-semibold text-text-primary mb-4" id="authentication">Hosted API authentication</h3>
         <p className="text-text-secondary mb-4">
-          POST your credentials to the Auth0 token endpoint to receive a JWT access token:
+          If you want PolicyEngine to host the API for you, the managed endpoint uses OAuth 2.0
+          client credentials. Contact{' '}
+          <a href="mailto:hello@policyengine.org" className="text-primary-600 hover:text-primary-700 underline">
+            hello@policyengine.org
+          </a>{' '}
+          to request API credentials, then POST those credentials to the Auth0 token endpoint to receive a JWT access token:
         </p>
 
         <CodeBlock code={curlExample} language="curl" title="curl" />

--- a/src/components/AuthSection.jsx
+++ b/src/components/AuthSection.jsx
@@ -6,6 +6,29 @@ import { IconLock, IconKey, IconShield } from '@tabler/icons-react';
 const dockerExample = `docker pull ghcr.io/policyengine/policyengine-household-api:latest
 docker run --rm -p 8080:8080 ghcr.io/policyengine/policyengine-household-api:latest`;
 
+const dockerSmokeTestExample = `curl --request POST \\
+  --url http://localhost:8080/us/calculate \\
+  --header 'Content-Type: application/json' \\
+  --data '{
+    "household": {
+      "people": {
+        "you": {
+          "employment_income": { "2025": 50000 }
+        }
+      },
+      "households": {
+        "your household": {
+          "members": ["you"],
+          "state_name": { "2025": "CA" }
+        }
+      },
+      "families": { "your family": { "members": ["you"] } },
+      "tax_units": { "your tax unit": { "members": ["you"] } },
+      "marital_units": { "your marital unit": { "members": ["you"] } },
+      "spm_units": { "your spm unit": { "members": ["you"] } }
+    }
+  }'`;
+
 const pythonModelExample = `pip install policyengine-us`;
 
 const pythonToolkitExample = `pip install "policyengine[us]"`;
@@ -80,6 +103,39 @@ export default function AuthSection() {
           </div>
         </div>
 
+        <div className="overflow-x-auto mb-12">
+          <table className="w-full text-sm border border-border-light rounded-lg overflow-hidden">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="px-4 py-3 text-left font-semibold">Option</th>
+                <th className="px-4 py-3 text-left font-semibold">Best for</th>
+                <th className="px-4 py-3 text-left font-semibold">Authentication</th>
+                <th className="px-4 py-3 text-left font-semibold">Wait time</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-t border-border-light">
+                <td className="px-4 py-3 font-medium">Hosted API</td>
+                <td className="px-4 py-3 text-text-secondary">Managed infrastructure and remote HTTP access</td>
+                <td className="px-4 py-3 text-text-secondary">OAuth client credentials</td>
+                <td className="px-4 py-3 text-text-secondary">Requires requesting access</td>
+              </tr>
+              <tr className="border-t border-border-light bg-gray-50">
+                <td className="px-4 py-3 font-medium">Docker image</td>
+                <td className="px-4 py-3 text-text-secondary">Self-hosting the HTTP API on your own machine or infra</td>
+                <td className="px-4 py-3 text-text-secondary">None by default</td>
+                <td className="px-4 py-3 text-text-secondary">Immediate</td>
+              </tr>
+              <tr className="border-t border-border-light">
+                <td className="px-4 py-3 font-medium">Python packages</td>
+                <td className="px-4 py-3 text-text-secondary">Direct model access inside Python workflows</td>
+                <td className="px-4 py-3 text-text-secondary">None</td>
+                <td className="px-4 py-3 text-text-secondary">Immediate</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
         <h3 className="text-2xl font-semibold text-text-primary mb-4">Self-serve without waiting</h3>
         <p className="text-text-secondary mb-6">
           These public options do not require an API key request.
@@ -136,6 +192,7 @@ export default function AuthSection() {
         </div>
 
         <CodeBlock code={dockerExample} language="bash" title="Docker (same HTTP API, self-hosted)" />
+        <CodeBlock code={dockerSmokeTestExample} language="curl" title="Quick Docker smoke test (no auth required)" />
 
         <div className="grid md:grid-cols-2 gap-6 mb-12">
           <CodeBlock code={pythonModelExample} language="bash" title="Direct US model (Python 3.11+)" />

--- a/src/components/AuthSection.jsx
+++ b/src/components/AuthSection.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import CodeBlock from './CodeBlock';
 import { IconLock, IconKey, IconShield } from '@tabler/icons-react';
 
@@ -90,6 +91,8 @@ const responseExample = `{
 }`;
 
 export default function AuthSection() {
+  const [selfServeTab, setSelfServeTab] = useState('docker');
+
   return (
     <section id="getting-started" className="py-16 border-b border-border-light">
       <div className="max-w-4xl mx-auto px-6">
@@ -169,54 +172,93 @@ export default function AuthSection() {
           These public options do not require an API key request.
         </p>
 
-        <div className="grid md:grid-cols-2 gap-6 mb-6">
-          <div className="p-5 rounded-lg border border-border-light bg-primary-50">
-            <h4 className="text-lg font-semibold text-text-primary mb-3">Public Docker image</h4>
-            <p className="text-text-secondary mb-3">
-              Run the household API locally or on your own infrastructure using the public container
-              image. The image uses the same REST interface as the hosted API, so you can send the
-              same request body to <code className="bg-white px-1.5 py-0.5 rounded text-sm">http://localhost:8080/us/calculate</code>.
-            </p>
-            <p className="text-sm text-text-secondary">
-              <a
-                href="https://github.com/PolicyEngine/policyengine-household-api/pkgs/container/policyengine-household-api"
-                className="text-primary-600 hover:text-primary-700 underline"
-              >
-                GitHub Container Registry
-              </a>{' '}
-              {' '}·{' '}
-              <a
-                href="https://github.com/PolicyEngine/policyengine-household-api/blob/main/config/README.md"
-                className="text-primary-600 hover:text-primary-700 underline"
-              >
-                configuration docs
-              </a>
-            </p>
-          </div>
-
-          <div className="p-5 rounded-lg border border-border-light bg-white">
-            <h4 className="text-lg font-semibold text-text-primary mb-3">Python package</h4>
-            <p className="text-text-secondary mb-3">
-              Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine-us</code> for
-              direct access to the US model in Python 3.11+. This is the closest Python alternative
-              to the household API for custom household calculations.
-            </p>
-            <p className="text-sm text-text-secondary">
-              <a
-                href="https://github.com/PolicyEngine/policyengine-us"
-                className="text-primary-600 hover:text-primary-700 underline"
-              >
-                policyengine-us
-              </a>
-            </p>
+        <div className="mb-6">
+          <div
+            className="inline-flex rounded-lg border border-border-light bg-gray-50 p-1"
+            role="tablist"
+            aria-label="Self-serve options"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={selfServeTab === 'docker'}
+              onClick={() => setSelfServeTab('docker')}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                selfServeTab === 'docker'
+                  ? 'bg-primary-600 text-white'
+                  : 'text-text-secondary hover:bg-gray-100'
+              }`}
+            >
+              Docker
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={selfServeTab === 'python'}
+              onClick={() => setSelfServeTab('python')}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                selfServeTab === 'python'
+                  ? 'bg-primary-600 text-white'
+                  : 'text-text-secondary hover:bg-gray-100'
+              }`}
+            >
+              Python
+            </button>
           </div>
         </div>
 
-        <CodeBlock code={dockerExample} language="bash" title="Docker (same HTTP API, self-hosted)" />
-        <CodeBlock code={dockerSmokeTestExample} language="curl" title="Quick Docker smoke test (no auth required)" />
+        {selfServeTab === 'docker' ? (
+          <div className="mb-12">
+            <div className="p-5 rounded-lg border border-border-light bg-primary-50 mb-4">
+              <h4 className="text-lg font-semibold text-text-primary mb-3">Public Docker image</h4>
+              <p className="text-text-secondary mb-3">
+                Run the household API locally or on your own infrastructure using the public container
+                image. The image uses the same REST interface as the hosted API, so you can send the
+                same request body to <code className="bg-white px-1.5 py-0.5 rounded text-sm">http://localhost:8080/us/calculate</code>.
+              </p>
+              <p className="text-sm text-text-secondary">
+                <a
+                  href="https://github.com/PolicyEngine/policyengine-household-api/pkgs/container/policyengine-household-api"
+                  className="text-primary-600 hover:text-primary-700 underline"
+                >
+                  GitHub Container Registry
+                </a>{' '}
+                {' '}·{' '}
+                <a
+                  href="https://github.com/PolicyEngine/policyengine-household-api/blob/main/config/README.md"
+                  className="text-primary-600 hover:text-primary-700 underline"
+                >
+                  configuration docs
+                </a>
+              </p>
+            </div>
 
-        <CodeBlock code={pythonInstallExample} language="bash" title="Install policyengine-us" />
-        <CodeBlock code={pythonDirectExample} language="python" title="Direct Python household calculation" />
+            <CodeBlock code={dockerExample} language="bash" title="Docker (same HTTP API, self-hosted)" />
+            <CodeBlock code={dockerSmokeTestExample} language="curl" title="Quick Docker smoke test (no auth required)" />
+          </div>
+        ) : (
+          <div className="mb-12">
+            <div className="p-5 rounded-lg border border-border-light bg-white mb-4">
+              <h4 className="text-lg font-semibold text-text-primary mb-3">Python package</h4>
+              <p className="text-text-secondary mb-3">
+                Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine-us</code> for
+                direct access to the US model in Python 3.11+. This is the closest Python alternative
+                to the household API for custom household calculations.
+              </p>
+              <p className="text-sm text-text-secondary">
+                <a
+                  href="https://github.com/PolicyEngine/policyengine-us"
+                  className="text-primary-600 hover:text-primary-700 underline"
+                >
+                  policyengine-us
+                </a>
+              </p>
+            </div>
+
+            <CodeBlock code={pythonInstallExample} language="bash" title="Install policyengine-us" />
+            <CodeBlock code={pythonDirectExample} language="python" title="Direct Python household calculation" />
+          </div>
+        )}
 
         <h3 className="text-2xl font-semibold text-text-primary mb-4" id="authentication">Hosted API authentication</h3>
         <p className="text-text-secondary mb-4">

--- a/src/components/AuthSection.jsx
+++ b/src/components/AuthSection.jsx
@@ -29,9 +29,36 @@ const dockerSmokeTestExample = `curl --request POST \\
     }
   }'`;
 
-const pythonModelExample = `pip install policyengine-us`;
+const pythonInstallExample = `pip install policyengine-us`;
 
-const pythonToolkitExample = `pip install "policyengine[us]"`;
+const pythonDirectExample = `from policyengine_us import Simulation
+
+household = {
+    "people": {
+        "you": {
+            "age": {"2025": 30},
+            "employment_income": {"2025": 50000},
+        },
+    },
+    "households": {
+        "your household": {
+            "members": ["you"],
+            "state_code": {"2025": "CA"},
+        },
+    },
+    "families": {"your family": {"members": ["you"]}},
+    "tax_units": {"your tax unit": {"members": ["you"]}},
+    "marital_units": {"your marital unit": {"members": ["you"]}},
+    "spm_units": {"your spm unit": {"members": ["you"]}},
+}
+
+sim = Simulation(situation=household)
+
+eitc = sim.calculate("eitc", "2025")[0]
+household_net_income = sim.calculate("household_net_income", "2025")[0]
+
+print(f"EITC: \${eitc:,.2f}")
+print(f"Household net income: \${household_net_income:,.2f}")`;
 
 const curlExample = `curl --request POST \\
   --url https://policyengine.uk.auth0.com/oauth/token \\
@@ -69,7 +96,8 @@ export default function AuthSection() {
         <h2 className="text-3xl font-bold text-text-primary mb-6">Getting started</h2>
         <p className="text-text-secondary mb-8 text-lg">
           You can use PolicyEngine three ways: our hosted API, the public household API Docker image,
-          or our Python packages. If you want to start immediately, use Docker or Python. If you want
+          or the <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine-us</code> Python package.
+          If you want to start immediately, use Docker or Python. If you want
           a managed hosted endpoint, request API credentials.
         </p>
 
@@ -95,7 +123,7 @@ export default function AuthSection() {
           <div className="p-4 rounded-lg border border-border-light bg-white">
             <div className="flex items-center gap-3 mb-2">
               <IconShield size={20} className="text-primary-600" />
-              <span className="font-semibold text-sm">Python packages</span>
+              <span className="font-semibold text-sm">Python package</span>
             </div>
             <p className="text-sm text-text-secondary">
               Call the US model directly from Python if you do not need an HTTP layer.
@@ -127,7 +155,7 @@ export default function AuthSection() {
                 <td className="px-4 py-3 text-text-secondary">Immediate</td>
               </tr>
               <tr className="border-t border-border-light">
-                <td className="px-4 py-3 font-medium">Python packages</td>
+                <td className="px-4 py-3 font-medium">Python package</td>
                 <td className="px-4 py-3 text-text-secondary">Direct model access inside Python workflows</td>
                 <td className="px-4 py-3 text-text-secondary">None</td>
                 <td className="px-4 py-3 text-text-secondary">Immediate</td>
@@ -167,11 +195,11 @@ export default function AuthSection() {
           </div>
 
           <div className="p-5 rounded-lg border border-border-light bg-white">
-            <h4 className="text-lg font-semibold text-text-primary mb-3">Python packages</h4>
+            <h4 className="text-lg font-semibold text-text-primary mb-3">Python package</h4>
             <p className="text-text-secondary mb-3">
               Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine-us</code> for
-              direct access to the US model in Python 3.11+, or <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine[us]</code>{' '}
-              for the higher-level analysis toolkit in Python 3.13+.
+              direct access to the US model in Python 3.11+. This is the closest Python alternative
+              to the household API for custom household calculations.
             </p>
             <p className="text-sm text-text-secondary">
               <a
@@ -179,13 +207,6 @@ export default function AuthSection() {
                 className="text-primary-600 hover:text-primary-700 underline"
               >
                 policyengine-us
-              </a>{' '}
-              {' '}·{' '}
-              <a
-                href="https://github.com/PolicyEngine/policyengine.py"
-                className="text-primary-600 hover:text-primary-700 underline"
-              >
-                policyengine.py
               </a>
             </p>
           </div>
@@ -194,10 +215,8 @@ export default function AuthSection() {
         <CodeBlock code={dockerExample} language="bash" title="Docker (same HTTP API, self-hosted)" />
         <CodeBlock code={dockerSmokeTestExample} language="curl" title="Quick Docker smoke test (no auth required)" />
 
-        <div className="grid md:grid-cols-2 gap-6 mb-12">
-          <CodeBlock code={pythonModelExample} language="bash" title="Direct US model (Python 3.11+)" />
-          <CodeBlock code={pythonToolkitExample} language="bash" title="Higher-level toolkit (Python 3.13+)" />
-        </div>
+        <CodeBlock code={pythonInstallExample} language="bash" title="Install policyengine-us" />
+        <CodeBlock code={pythonDirectExample} language="python" title="Direct Python household calculation" />
 
         <h3 className="text-2xl font-semibold text-text-primary mb-4" id="authentication">Hosted API authentication</h3>
         <p className="text-text-secondary mb-4">

--- a/src/components/AuthSection.jsx
+++ b/src/components/AuthSection.jsx
@@ -2,33 +2,12 @@
 
 import CodeBlock from './CodeBlock';
 import { IconLock, IconKey, IconShield } from '@tabler/icons-react';
-import { ACCESS_MODE_OPTIONS } from './accessModes';
+import { getAccessModeOption } from './accessModes';
 
 const dockerExample = `docker pull ghcr.io/policyengine/policyengine-household-api:latest
 docker run --rm -p 8080:8080 ghcr.io/policyengine/policyengine-household-api:latest`;
 
-const dockerSmokeTestExample = `curl --request POST \\
-  --url http://localhost:8080/us/calculate \\
-  --header 'Content-Type: application/json' \\
-  --data '{
-    "household": {
-      "people": {
-        "you": {
-          "employment_income": { "2025": 50000 }
-        }
-      },
-      "households": {
-        "your household": {
-          "members": ["you"],
-          "state_name": { "2025": "CA" }
-        }
-      },
-      "families": { "your family": { "members": ["you"] } },
-      "tax_units": { "your tax unit": { "members": ["you"] } },
-      "marital_units": { "your marital unit": { "members": ["you"] } },
-      "spm_units": { "your spm unit": { "members": ["you"] } }
-    }
-  }'`;
+const dockerSmokeTestExample = `curl http://localhost:8080/`;
 
 const pythonInstallExample = `pip install policyengine-us`;
 
@@ -91,8 +70,7 @@ const responseExample = `{
 }`;
 
 export default function AuthSection({ accessMode }) {
-  const selectedMode =
-    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
+  const selectedMode = getAccessModeOption(accessMode);
 
   return (
     <section id="getting-started" className="py-16 border-b border-border-light">
@@ -213,8 +191,7 @@ export default function AuthSection({ accessMode }) {
                   className="text-primary-600 hover:text-primary-700 underline"
                 >
                   GitHub Container Registry
-                </a>{' '}
-                {' '}·{' '}
+                </a>{' '}·{' '}
                 <a
                   href="https://github.com/PolicyEngine/policyengine-household-api/blob/main/config/README.md"
                   className="text-primary-600 hover:text-primary-700 underline"
@@ -225,7 +202,7 @@ export default function AuthSection({ accessMode }) {
             </div>
 
             <CodeBlock code={dockerExample} language="bash" title="Docker (same HTTP API, self-hosted)" />
-            <CodeBlock code={dockerSmokeTestExample} language="curl" title="Quick Docker smoke test (no auth required)" />
+            <CodeBlock code={dockerSmokeTestExample} language="bash" title="Quick Docker smoke test (service metadata)" />
           </div>
         ) : (
           <div className="mb-12">

--- a/src/components/AuthSection.jsx
+++ b/src/components/AuthSection.jsx
@@ -91,7 +91,7 @@ const responseExample = `{
 }`;
 
 export default function AuthSection() {
-  const [selfServeTab, setSelfServeTab] = useState('docker');
+  const [accessTab, setAccessTab] = useState('rest');
 
   return (
     <section id="getting-started" className="py-16 border-b border-border-light">
@@ -167,24 +167,38 @@ export default function AuthSection() {
           </table>
         </div>
 
-        <h3 className="text-2xl font-semibold text-text-primary mb-4">Self-serve without waiting</h3>
+        <h3 className="text-2xl font-semibold text-text-primary mb-4">Choose an access path</h3>
         <p className="text-text-secondary mb-6">
-          These public options do not require an API key request.
+          Pick the path that matches how you want to use PolicyEngine: hosted REST API, self-hosted Docker,
+          or direct Python access.
         </p>
 
         <div className="mb-6">
           <div
             className="inline-flex rounded-lg border border-border-light bg-gray-50 p-1"
             role="tablist"
-            aria-label="Self-serve options"
+            aria-label="Access options"
           >
             <button
               type="button"
               role="tab"
-              aria-selected={selfServeTab === 'docker'}
-              onClick={() => setSelfServeTab('docker')}
+              aria-selected={accessTab === 'rest'}
+              onClick={() => setAccessTab('rest')}
               className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                selfServeTab === 'docker'
+                accessTab === 'rest'
+                  ? 'bg-primary-600 text-white'
+                  : 'text-text-secondary hover:bg-gray-100'
+              }`}
+            >
+              REST API
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={accessTab === 'docker'}
+              onClick={() => setAccessTab('docker')}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                accessTab === 'docker'
                   ? 'bg-primary-600 text-white'
                   : 'text-text-secondary hover:bg-gray-100'
               }`}
@@ -194,10 +208,10 @@ export default function AuthSection() {
             <button
               type="button"
               role="tab"
-              aria-selected={selfServeTab === 'python'}
-              onClick={() => setSelfServeTab('python')}
+              aria-selected={accessTab === 'python'}
+              onClick={() => setAccessTab('python')}
               className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                selfServeTab === 'python'
+                accessTab === 'python'
                   ? 'bg-primary-600 text-white'
                   : 'text-text-secondary hover:bg-gray-100'
               }`}
@@ -207,7 +221,31 @@ export default function AuthSection() {
           </div>
         </div>
 
-        {selfServeTab === 'docker' ? (
+        {accessTab === 'rest' ? (
+          <div className="mb-12">
+            <div className="p-5 rounded-lg border border-border-light bg-white mb-4">
+              <h4 className="text-lg font-semibold text-text-primary mb-3">Hosted REST API</h4>
+              <p className="text-text-secondary mb-3">
+                Use PolicyEngine&apos;s managed HTTP endpoint if you want a hosted integration rather than
+                running the API yourself. This path requires OAuth client credentials issued by PolicyEngine.
+              </p>
+              <p className="text-sm text-text-secondary">
+                Contact{' '}
+                <a
+                  href="mailto:hello@policyengine.org"
+                  className="text-primary-600 hover:text-primary-700 underline"
+                >
+                  hello@policyengine.org
+                </a>{' '}
+                to request API credentials.
+              </p>
+            </div>
+
+            <CodeBlock code={curlExample} language="curl" title="Fetch an access token" />
+            <CodeBlock code={pythonExample} language="python" title="Fetch an access token in Python" />
+            <CodeBlock code={responseExample} language="json" title="Token response" />
+          </div>
+        ) : accessTab === 'docker' ? (
           <div className="mb-12">
             <div className="p-5 rounded-lg border border-border-light bg-primary-50 mb-4">
               <h4 className="text-lg font-semibold text-text-primary mb-3">Public Docker image</h4>
@@ -259,22 +297,6 @@ export default function AuthSection() {
             <CodeBlock code={pythonDirectExample} language="python" title="Direct Python household calculation" />
           </div>
         )}
-
-        <h3 className="text-2xl font-semibold text-text-primary mb-4" id="authentication">Hosted API authentication</h3>
-        <p className="text-text-secondary mb-4">
-          If you want PolicyEngine to host the API for you, the managed endpoint uses OAuth 2.0
-          client credentials. Contact{' '}
-          <a href="mailto:hello@policyengine.org" className="text-primary-600 hover:text-primary-700 underline">
-            hello@policyengine.org
-          </a>{' '}
-          to request API credentials, then POST those credentials to the Auth0 token endpoint to receive a JWT access token:
-        </p>
-
-        <CodeBlock code={curlExample} language="curl" title="curl" />
-        <CodeBlock code={pythonExample} language="python" title="Python" />
-
-        <h4 className="text-lg font-semibold text-text-primary mt-8 mb-3">Response</h4>
-        <CodeBlock code={responseExample} language="json" title="JSON response" />
       </div>
     </section>
   );

--- a/src/components/AuthSection.jsx
+++ b/src/components/AuthSection.jsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
 import CodeBlock from './CodeBlock';
 import { IconLock, IconKey, IconShield } from '@tabler/icons-react';
+import { ACCESS_MODE_OPTIONS } from './accessModes';
 
 const dockerExample = `docker pull ghcr.io/policyengine/policyengine-household-api:latest
 docker run --rm -p 8080:8080 ghcr.io/policyengine/policyengine-household-api:latest`;
@@ -44,7 +44,7 @@ household = {
     "households": {
         "your household": {
             "members": ["you"],
-            "state_code": {"2025": "CA"},
+            "state_name": {"2025": "CA"},
         },
     },
     "families": {"your family": {"members": ["you"]}},
@@ -90,8 +90,9 @@ const responseExample = `{
   "token_type": "Bearer"
 }`;
 
-export default function AuthSection() {
-  const [accessTab, setAccessTab] = useState('rest');
+export default function AuthSection({ accessMode }) {
+  const selectedMode =
+    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
 
   return (
     <section id="getting-started" className="py-16 border-b border-border-light">
@@ -167,61 +168,13 @@ export default function AuthSection() {
           </table>
         </div>
 
-        <h3 className="text-2xl font-semibold text-text-primary mb-4">Choose an access path</h3>
+        <h3 className="text-2xl font-semibold text-text-primary mb-4">Selected access path</h3>
         <p className="text-text-secondary mb-6">
-          Pick the path that matches how you want to use PolicyEngine: hosted REST API, self-hosted Docker,
-          or direct Python access.
+          The page is currently showing <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">{selectedMode.label}</code>{' '}
+          examples. Use the sticky selector above to switch the whole page into a different integration path.
         </p>
 
-        <div className="mb-6">
-          <div
-            className="inline-flex rounded-lg border border-border-light bg-gray-50 p-1"
-            role="tablist"
-            aria-label="Access options"
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={accessTab === 'rest'}
-              onClick={() => setAccessTab('rest')}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                accessTab === 'rest'
-                  ? 'bg-primary-600 text-white'
-                  : 'text-text-secondary hover:bg-gray-100'
-              }`}
-            >
-              REST API
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={accessTab === 'docker'}
-              onClick={() => setAccessTab('docker')}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                accessTab === 'docker'
-                  ? 'bg-primary-600 text-white'
-                  : 'text-text-secondary hover:bg-gray-100'
-              }`}
-            >
-              Docker
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={accessTab === 'python'}
-              onClick={() => setAccessTab('python')}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                accessTab === 'python'
-                  ? 'bg-primary-600 text-white'
-                  : 'text-text-secondary hover:bg-gray-100'
-              }`}
-            >
-              Python
-            </button>
-          </div>
-        </div>
-
-        {accessTab === 'rest' ? (
+        {accessMode === 'rest' ? (
           <div className="mb-12">
             <div className="p-5 rounded-lg border border-border-light bg-white mb-4">
               <h4 className="text-lg font-semibold text-text-primary mb-3">Hosted REST API</h4>
@@ -245,7 +198,7 @@ export default function AuthSection() {
             <CodeBlock code={pythonExample} language="python" title="Fetch an access token in Python" />
             <CodeBlock code={responseExample} language="json" title="Token response" />
           </div>
-        ) : accessTab === 'docker' ? (
+        ) : accessMode === 'docker' ? (
           <div className="mb-12">
             <div className="p-5 rounded-lg border border-border-light bg-primary-50 mb-4">
               <h4 className="text-lg font-semibold text-text-primary mb-3">Public Docker image</h4>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -13,8 +13,8 @@ export default function HeroSection() {
           PolicyEngine household API
         </h1>
         <p className="text-lg md:text-xl text-text-secondary max-w-2xl mx-auto">
-          Simulate tax and benefit policy outcomes for any US household using PolicyEngine&apos;s REST API.
-          Calculate income taxes, credits, and benefit eligibility programmatically.
+          Simulate tax and benefit policy outcomes for any US household with our hosted REST API,
+          public Docker image, or Python packages.
         </p>
       </div>
     </section>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -14,7 +14,8 @@ export default function HeroSection() {
         </h1>
         <p className="text-lg md:text-xl text-text-secondary max-w-2xl mx-auto">
           Simulate tax and benefit policy outcomes for any US household with our hosted REST API,
-          public Docker image, or the `policyengine-us` Python package.
+          public Docker image, or the <code className="bg-white px-1.5 py-0.5 rounded text-base">policyengine-us</code>{' '}
+          Python package for direct in-process access.
         </p>
       </div>
     </section>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -14,7 +14,7 @@ export default function HeroSection() {
         </h1>
         <p className="text-lg md:text-xl text-text-secondary max-w-2xl mx-auto">
           Simulate tax and benefit policy outcomes for any US household with our hosted REST API,
-          public Docker image, or Python packages.
+          public Docker image, or the `policyengine-us` Python package.
         </p>
       </div>
     </section>

--- a/src/components/HouseholdSection.jsx
+++ b/src/components/HouseholdSection.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import CodeBlock from './CodeBlock';
+import { ACCESS_MODE_OPTIONS } from './accessModes';
 
 const step1 = `{
   "people": {},
@@ -90,7 +91,7 @@ const step3 = `{
   }
 }`;
 
-const fullExample = `import requests
+const hostedFullExample = `import requests
 
 token = "YOUR_ACCESS_TOKEN"
 
@@ -147,7 +148,123 @@ result = response.json()
 eitc = result["tax_units"]["my tax unit"]["eitc"]["2025"]
 print(f"EITC: \${eitc:,.2f}")`;
 
-export default function HouseholdSection() {
+const dockerFullExample = `import requests
+
+household = {
+    "people": {
+        "adult1": {
+            "age": {"2025": 40},
+            "employment_income": {"2025": 30000},
+        },
+        "adult2": {
+            "age": {"2025": 38},
+            "employment_income": {"2025": 20000},
+        },
+        "child1": {"age": {"2025": 10}},
+        "child2": {"age": {"2025": 7}},
+    },
+    "households": {
+        "my household": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+            "state_name": {"2025": "AZ"},
+        },
+    },
+    "families": {
+        "my family": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+        },
+    },
+    "tax_units": {
+        "my tax unit": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+        },
+    },
+    "marital_units": {
+        "my marital unit": {
+            "members": ["adult1", "adult2"],
+        },
+    },
+    "spm_units": {
+        "my spm unit": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+        },
+    },
+}
+
+response = requests.post(
+    "http://localhost:8080/us/calculate",
+    json={"household": household},
+)
+
+result = response.json()
+
+eitc = result["tax_units"]["my tax unit"]["eitc"]["2025"]
+print(f"EITC: \${eitc:,.2f}")`;
+
+const pythonFullExample = `from policyengine_us import Simulation
+
+household = {
+    "people": {
+        "adult1": {
+            "age": {"2025": 40},
+            "employment_income": {"2025": 30000},
+        },
+        "adult2": {
+            "age": {"2025": 38},
+            "employment_income": {"2025": 20000},
+        },
+        "child1": {"age": {"2025": 10}},
+        "child2": {"age": {"2025": 7}},
+    },
+    "households": {
+        "my household": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+            "state_name": {"2025": "AZ"},
+        },
+    },
+    "families": {
+        "my family": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+        },
+    },
+    "tax_units": {
+        "my tax unit": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+        },
+    },
+    "marital_units": {
+        "my marital unit": {
+            "members": ["adult1", "adult2"],
+        },
+    },
+    "spm_units": {
+        "my spm unit": {
+            "members": ["adult1", "adult2", "child1", "child2"],
+        },
+    },
+}
+
+sim = Simulation(situation=household)
+
+eitc = sim.calculate("eitc", "2025")[0]
+print(f"EITC: \${eitc:,.2f}")`;
+
+export default function HouseholdSection({ accessMode }) {
+  const selectedMode =
+    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
+  const fullExample =
+    accessMode === 'rest'
+      ? hostedFullExample
+      : accessMode === 'docker'
+        ? dockerFullExample
+        : pythonFullExample;
+  const exampleTitle =
+    accessMode === 'rest'
+      ? 'Complete EITC example via hosted REST API'
+      : accessMode === 'docker'
+        ? 'Complete EITC example via self-hosted Docker'
+        : 'Complete EITC example via policyengine-us';
+
   return (
     <section id="household-objects" className="py-16 border-b border-border-light bg-bg-secondary">
       <div className="max-w-4xl mx-auto px-6">
@@ -260,7 +377,13 @@ export default function HouseholdSection() {
           Putting it all together &mdash; a married couple in Arizona with two children and $50,000 combined income,
           calculating their Earned Income Tax Credit:
         </p>
-        <CodeBlock code={fullExample} language="python" title="Complete EITC example" />
+        <p className="text-sm text-text-tertiary mb-4">
+          Current access path:{' '}
+          <span className="inline-flex items-center rounded-full bg-primary-50 px-2.5 py-1 font-medium text-primary-700">
+            {selectedMode.label}
+          </span>
+        </p>
+        <CodeBlock code={fullExample} language="python" title={exampleTitle} />
       </div>
     </section>
   );

--- a/src/components/HouseholdSection.jsx
+++ b/src/components/HouseholdSection.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import CodeBlock from './CodeBlock';
-import { ACCESS_MODE_OPTIONS } from './accessModes';
+import { getAccessModeOption } from './accessModes';
 
 const step1 = `{
   "people": {},
@@ -250,8 +250,7 @@ eitc = sim.calculate("eitc", "2025")[0]
 print(f"EITC: \${eitc:,.2f}")`;
 
 export default function HouseholdSection({ accessMode }) {
-  const selectedMode =
-    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
+  const selectedMode = getAccessModeOption(accessMode);
   const fullExample =
     accessMode === 'rest'
       ? hostedFullExample

--- a/src/components/RequestSection.jsx
+++ b/src/components/RequestSection.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import CodeBlock from './CodeBlock';
 
 const hostedCurlRequest = `curl --request POST \\
@@ -26,20 +27,19 @@ const hostedCurlRequest = `curl --request POST \\
     }
   }'`;
 
-const pythonRequest = `import requests
-
-token = "YOUR_ACCESS_TOKEN"
+const pythonRequest = `from policyengine_us import Simulation
 
 household = {
     "people": {
         "you": {
+            "age": {"2025": 30},
             "employment_income": {"2025": 50000},
         },
     },
     "households": {
         "your household": {
             "members": ["you"],
-            "state_name": {"2025": "CA"},
+            "state_code": {"2025": "CA"},
         },
     },
     "families": {"your family": {"members": ["you"]}},
@@ -48,13 +48,14 @@ household = {
     "spm_units": {"your spm unit": {"members": ["you"]}},
 }
 
-response = requests.post(
-    "https://household.api.policyengine.org/us/calculate",
-    json={"household": household},
-    headers={"Authorization": f"Bearer {token}"},
-)
+sim = Simulation(situation=household)
 
-result = response.json()`;
+results = {
+    "eitc": sim.calculate("eitc", "2025")[0],
+    "household_net_income": sim.calculate("household_net_income", "2025")[0],
+}
+
+print(results)`;
 
 const dockerCurlRequest = `curl --request POST \\
   --url http://localhost:8080/us/calculate \\
@@ -80,36 +81,99 @@ const dockerCurlRequest = `curl --request POST \\
   }'`;
 
 export default function RequestSection() {
+  const [requestTab, setRequestTab] = useState('rest');
+  const tabOptions = [
+    { id: 'rest', label: 'REST API' },
+    { id: 'docker', label: 'Docker' },
+    { id: 'python', label: 'Python' },
+  ];
+
   return (
     <section id="making-requests" className="py-16 border-b border-border-light">
       <div className="max-w-4xl mx-auto px-6">
-        <h2 className="text-3xl font-bold text-text-primary mb-6">Making requests</h2>
+        <h2 className="text-3xl font-bold text-text-primary mb-6">Running a calculation</h2>
         <p className="text-text-secondary mb-4 text-lg">
-          Send a POST request to the calculate endpoint with your household object:
+          Choose the interface you are using and start from the matching example. Hosted REST, self-hosted
+          Docker, and direct Python access all let you evaluate the same US household policies.
         </p>
 
-        <div className="p-4 rounded-lg bg-primary-50 border border-primary-200 mb-6">
-          <code className="text-sm font-mono font-semibold text-primary-800">
-            POST https://household.api.policyengine.org/us/calculate
-          </code>
+        <div className="mb-6">
+          <div
+            className="inline-flex rounded-lg border border-border-light bg-gray-50 p-1"
+            role="tablist"
+            aria-label="Request examples"
+          >
+            {tabOptions.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={requestTab === tab.id}
+                onClick={() => setRequestTab(tab.id)}
+                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                  requestTab === tab.id
+                    ? 'bg-primary-600 text-white'
+                    : 'text-text-secondary hover:bg-gray-100'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
         </div>
 
-        <p className="text-text-secondary mb-4">
-          If you are running the public Docker image locally, use{' '}
-          <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">http://localhost:8080/us/calculate</code>{' '}
-          instead.
-        </p>
-
-        <p className="text-text-secondary mb-4">
-          The request body must contain a <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">household</code> key
-          with your household object. The response returns the same structure with all computable variables filled in.
-        </p>
-
-        <div className="grid md:grid-cols-2 gap-6">
-          <CodeBlock code={hostedCurlRequest} language="curl" title="Hosted API (Bearer token required)" />
-          <CodeBlock code={dockerCurlRequest} language="curl" title="Self-hosted Docker (no auth by default)" />
-        </div>
-        <CodeBlock code={pythonRequest} language="python" title="Python" />
+        {requestTab === 'rest' ? (
+          <>
+            <p className="text-text-secondary mb-4">
+              Send a POST request to the hosted calculate endpoint with your household object and a bearer token.
+            </p>
+            <div className="p-4 rounded-lg bg-primary-50 border border-primary-200 mb-6">
+              <code className="text-sm font-mono font-semibold text-primary-800">
+                POST https://household.api.policyengine.org/us/calculate
+              </code>
+            </div>
+            <p className="text-text-secondary mb-4">
+              The request body must contain a <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">household</code>{' '}
+              key with your household object. The response returns the same structure with all computable variables
+              filled in.
+            </p>
+            <CodeBlock code={hostedCurlRequest} language="curl" title="Hosted API request" />
+          </>
+        ) : requestTab === 'docker' ? (
+          <>
+            <p className="text-text-secondary mb-4">
+              Send the same POST request to your local or self-hosted container. The public Docker image does not
+              require authentication by default.
+            </p>
+            <div className="p-4 rounded-lg bg-primary-50 border border-primary-200 mb-6">
+              <code className="text-sm font-mono font-semibold text-primary-800">
+                POST http://localhost:8080/us/calculate
+              </code>
+            </div>
+            <p className="text-text-secondary mb-4">
+              The request body must contain a <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">household</code>{' '}
+              key with your household object. The response returns the same structure with all computable variables
+              filled in.
+            </p>
+            <CodeBlock code={dockerCurlRequest} language="curl" title="Docker request" />
+          </>
+        ) : (
+          <>
+            <p className="text-text-secondary mb-4">
+              Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">policyengine-us</code> when you want
+              to call the US model directly from Python instead of going through HTTP.
+            </p>
+            <div className="p-4 rounded-lg bg-primary-50 border border-primary-200 mb-6">
+              <code className="text-sm font-mono font-semibold text-primary-800">pip install policyengine-us</code>
+            </div>
+            <p className="text-text-secondary mb-4">
+              Build a household object in Python, pass it to{' '}
+              <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">Simulation(situation=...)</code>, and
+              calculate the variables you need directly in process.
+            </p>
+            <CodeBlock code={pythonRequest} language="python" title="Python package example" />
+          </>
+        )}
       </div>
     </section>
   );

--- a/src/components/RequestSection.jsx
+++ b/src/components/RequestSection.jsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import CodeBlock from './CodeBlock';
+import { ACCESS_MODE_OPTIONS } from './accessModes';
 
 const hostedCurlRequest = `curl --request POST \\
   --url https://household.api.policyengine.org/us/calculate \\
@@ -39,7 +39,7 @@ household = {
     "households": {
         "your household": {
             "members": ["you"],
-            "state_code": {"2025": "CA"},
+            "state_name": {"2025": "CA"},
         },
     },
     "families": {"your family": {"members": ["you"]}},
@@ -80,49 +80,26 @@ const dockerCurlRequest = `curl --request POST \\
     }
   }'`;
 
-export default function RequestSection() {
-  const [requestTab, setRequestTab] = useState('rest');
-  const tabOptions = [
-    { id: 'rest', label: 'REST API' },
-    { id: 'docker', label: 'Docker' },
-    { id: 'python', label: 'Python' },
-  ];
+export default function RequestSection({ accessMode }) {
+  const selectedMode =
+    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
 
   return (
     <section id="making-requests" className="py-16 border-b border-border-light">
       <div className="max-w-4xl mx-auto px-6">
         <h2 className="text-3xl font-bold text-text-primary mb-6">Running a calculation</h2>
         <p className="text-text-secondary mb-4 text-lg">
-          Choose the interface you are using and start from the matching example. Hosted REST, self-hosted
-          Docker, and direct Python access all let you evaluate the same US household policies.
+          The request examples below follow your selected access path. Hosted REST, self-hosted Docker,
+          and direct Python access all evaluate the same US household policies.
+        </p>
+        <p className="text-sm text-text-tertiary mb-6">
+          Current access path:{' '}
+          <span className="inline-flex items-center rounded-full bg-primary-50 px-2.5 py-1 font-medium text-primary-700">
+            {selectedMode.label}
+          </span>
         </p>
 
-        <div className="mb-6">
-          <div
-            className="inline-flex rounded-lg border border-border-light bg-gray-50 p-1"
-            role="tablist"
-            aria-label="Request examples"
-          >
-            {tabOptions.map((tab) => (
-              <button
-                key={tab.id}
-                type="button"
-                role="tab"
-                aria-selected={requestTab === tab.id}
-                onClick={() => setRequestTab(tab.id)}
-                className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                  requestTab === tab.id
-                    ? 'bg-primary-600 text-white'
-                    : 'text-text-secondary hover:bg-gray-100'
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {requestTab === 'rest' ? (
+        {accessMode === 'rest' ? (
           <>
             <p className="text-text-secondary mb-4">
               Send a POST request to the hosted calculate endpoint with your household object and a bearer token.
@@ -139,7 +116,7 @@ export default function RequestSection() {
             </p>
             <CodeBlock code={hostedCurlRequest} language="curl" title="Hosted API request" />
           </>
-        ) : requestTab === 'docker' ? (
+        ) : accessMode === 'docker' ? (
           <>
             <p className="text-text-secondary mb-4">
               Send the same POST request to your local or self-hosted container. The public Docker image does not

--- a/src/components/RequestSection.jsx
+++ b/src/components/RequestSection.jsx
@@ -2,7 +2,7 @@
 
 import CodeBlock from './CodeBlock';
 
-const curlRequest = `curl --request POST \\
+const hostedCurlRequest = `curl --request POST \\
   --url https://household.api.policyengine.org/us/calculate \\
   --header 'Authorization: Bearer YOUR_ACCESS_TOKEN' \\
   --header 'Content-Type: application/json' \\
@@ -56,6 +56,29 @@ response = requests.post(
 
 result = response.json()`;
 
+const dockerCurlRequest = `curl --request POST \\
+  --url http://localhost:8080/us/calculate \\
+  --header 'Content-Type: application/json' \\
+  --data '{
+    "household": {
+      "people": {
+        "you": {
+          "employment_income": { "2025": 50000 }
+        }
+      },
+      "households": {
+        "your household": {
+          "members": ["you"],
+          "state_name": { "2025": "CA" }
+        }
+      },
+      "families": { "your family": { "members": ["you"] } },
+      "tax_units": { "your tax unit": { "members": ["you"] } },
+      "marital_units": { "your marital unit": { "members": ["you"] } },
+      "spm_units": { "your spm unit": { "members": ["you"] } }
+    }
+  }'`;
+
 export default function RequestSection() {
   return (
     <section id="making-requests" className="py-16 border-b border-border-light">
@@ -82,7 +105,10 @@ export default function RequestSection() {
           with your household object. The response returns the same structure with all computable variables filled in.
         </p>
 
-        <CodeBlock code={curlRequest} language="curl" title="curl" />
+        <div className="grid md:grid-cols-2 gap-6">
+          <CodeBlock code={hostedCurlRequest} language="curl" title="Hosted API (Bearer token required)" />
+          <CodeBlock code={dockerCurlRequest} language="curl" title="Self-hosted Docker (no auth by default)" />
+        </div>
         <CodeBlock code={pythonRequest} language="python" title="Python" />
       </div>
     </section>

--- a/src/components/RequestSection.jsx
+++ b/src/components/RequestSection.jsx
@@ -72,6 +72,12 @@ export default function RequestSection() {
         </div>
 
         <p className="text-text-secondary mb-4">
+          If you are running the public Docker image locally, use{' '}
+          <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">http://localhost:8080/us/calculate</code>{' '}
+          instead.
+        </p>
+
+        <p className="text-text-secondary mb-4">
           The request body must contain a <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">household</code> key
           with your household object. The response returns the same structure with all computable variables filled in.
         </p>

--- a/src/components/RequestSection.jsx
+++ b/src/components/RequestSection.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import CodeBlock from './CodeBlock';
-import { ACCESS_MODE_OPTIONS } from './accessModes';
+import { getAccessModeOption } from './accessModes';
 
 const hostedCurlRequest = `curl --request POST \\
   --url https://household.api.policyengine.org/us/calculate \\
@@ -11,6 +11,7 @@ const hostedCurlRequest = `curl --request POST \\
     "household": {
       "people": {
         "you": {
+          "age": { "2025": 30 },
           "employment_income": { "2025": 50000 }
         }
       },
@@ -64,6 +65,7 @@ const dockerCurlRequest = `curl --request POST \\
     "household": {
       "people": {
         "you": {
+          "age": { "2025": 30 },
           "employment_income": { "2025": 50000 }
         }
       },
@@ -81,8 +83,7 @@ const dockerCurlRequest = `curl --request POST \\
   }'`;
 
 export default function RequestSection({ accessMode }) {
-  const selectedMode =
-    ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
+  const selectedMode = getAccessModeOption(accessMode);
 
   return (
     <section id="making-requests" className="py-16 border-b border-border-light">

--- a/src/components/accessModes.js
+++ b/src/components/accessModes.js
@@ -15,3 +15,7 @@ export const ACCESS_MODE_OPTIONS = [
     description: 'Call the US model directly with policyengine-us when you do not need an HTTP layer.',
   },
 ];
+
+export function getAccessModeOption(accessMode) {
+  return ACCESS_MODE_OPTIONS.find((option) => option.id === accessMode) ?? ACCESS_MODE_OPTIONS[0];
+}

--- a/src/components/accessModes.js
+++ b/src/components/accessModes.js
@@ -1,0 +1,17 @@
+export const ACCESS_MODE_OPTIONS = [
+  {
+    id: 'rest',
+    label: 'REST API',
+    description: 'Use the hosted PolicyEngine endpoint with OAuth credentials issued by PolicyEngine.',
+  },
+  {
+    id: 'docker',
+    label: 'Docker',
+    description: 'Run the published household API image on your own machine or infrastructure.',
+  },
+  {
+    id: 'python',
+    label: 'Python',
+    description: 'Call the US model directly with policyengine-us when you do not need an HTTP layer.',
+  },
+];


### PR DESCRIPTION
## Summary
- clarify that developers can start without waiting for hosted API credentials
- add self-serve Docker guidance with the public household API container image
- add Python package options for direct US-model access and the higher-level toolkit
- keep OAuth instructions, but frame them specifically as the hosted API path

## Testing
- `bun run build`