### PR TITLE
Fix broken page styles on /us/api and /uk/api

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,9 @@
   "framework": null,
   "buildCommand": "bun run build",
   "outputDirectory": "out",
+  "redirects": [
+    { "source": "/:countryId/api", "destination": "/:countryId/api/", "statusCode": 308 }
+  ],
   "rewrites": [
     { "source": "/:countryId/api/_next/:path*", "destination": "/_next/:path*" }
   ]


### PR DESCRIPTION
## What's broken

The API docs pages (`/us/api`, `/uk/api`) appear unstyled — content is there but the visual formatting is missing. This affects both the standalone site and when viewed through policyengine.org.

## Why

PR #5 changed the app's URL configuration from `basePath: '/us/api'` (which only supported US) to `assetPrefix: '.'` (to support both `/us/api` and `/uk/api`). Before this change, `basePath` handled asset paths correctly and styles always loaded.

With `assetPrefix: '.'`, the CSS is referenced using a relative path. This creates a sensitivity to whether the URL has a trailing slash:
- `/us/api/` (with slash) — browser finds the CSS correctly
- `/us/api` (without slash) — browser looks in the wrong location, CSS fails to load

Users and links typically don't include the trailing slash, so the page appears unstyled.

Companion change on policyengine-app-v2: PR #874 (added `/uk/api` rewrites, merged the same day).

## Fix

Automatically redirects `/us/api` to `/us/api/` (and `/uk/api` to `/uk/api/`) so styling always loads correctly. 3 lines added to `vercel.json`.

No changes to the app's content, design, or architecture. No impact on users — the redirect is invisible.

## Why not a bigger architectural change?

The app serves static documentation for 2 countries. Switching to a dynamic server deployment (which would avoid this URL issue entirely) would be overkill for this use case. The redirect is the proportionate fix. If the app grows to support many more country routes or dynamic content, the architecture can be revisited then.