### PR TITLE
Remove relative asset prefix for exported docs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  assetPrefix: '.',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary
- remove the relative asset prefix from next.config.mjs
- stop exported nested routes like /us/api/ from emitting relative ./_next/... asset URLs
- keep the existing trailing-slash redirect behavior from the previous fix, but resolve the styling issue at the source instead of relying on route-specific rewrites

## Verification
- npm run build
- inspected out/us/api/index.html and confirmed it now emits /_next/... asset URLs instead of ./_next/...
- fetched the live deployed page and confirmed it is still currently serving broken relative asset URLs

## Why this is needed
The live /us/api/ deployment is still serving relative asset paths, which causes CSS and JS to resolve under /us/api/_next/... and break styling on nested routes.