### PR TITLE
Add asset prefix for multi-zone proxy support

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  assetPrefix: '/_zones/household-api-docs',
   images: {
     unoptimized: true,
   },

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
     { "source": "/:countryId/api", "destination": "/:countryId/api/", "statusCode": 308 }
   ],
   "rewrites": [
+    { "source": "/_zones/household-api-docs/_next/:path*", "destination": "/_next/:path*" },
     { "source": "/:countryId/api/_next/:path*", "destination": "/_next/:path*" }
   ]
 }


### PR DESCRIPTION
Adds a unique asset prefix so the API docs can be served through policyengine.org via a Vercel rewrite without CSS/JS path collisions.

Without this, when policyengine.org proxies the API docs page, the browser tries to load CSS/JS from policyengine.org/_next/... which serves the wrong app's assets.

Changes:
- next.config.mjs: add assetPrefix: '/_zones/household-api-docs'
- vercel.json: add rewrite for the new prefix path to serve assets correctly on the standalone deployment

The host app (policyengine-app-v2) will add a corresponding rewrite: /_zones/household-api-docs/:path* → this deployment.

Convention: all zone apps use /_zones/{repo-name} as the prefix.