### PR TITLE
Add API terms pages and docs link

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,15 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: 'export',
-  assetPrefix: '/_zones/household-api-docs',
-  images: {
-    unoptimized: true,
-  },
-  trailingSlash: true,
-};
+import { PHASE_DEVELOPMENT_SERVER } from 'next/constants.js';
 
-export default nextConfig;
+export default function nextConfig(phase) {
+  const isDev = phase === PHASE_DEVELOPMENT_SERVER;
+
+  /** @type {import('next').NextConfig} */
+  return {
+    output: 'export',
+    assetPrefix: isDev ? undefined : '/_zones/household-api-docs',
+    images: {
+      unoptimized: true,
+    },
+    trailingSlash: true,
+  };
+}

--- a/src/app/[countryId]/api/page.jsx
+++ b/src/app/[countryId]/api/page.jsx
@@ -8,8 +8,9 @@ export function generateStaticParams() {
   return SUPPORTED_COUNTRY_IDS.map((countryId) => ({ countryId }));
 }
 
-export function generateMetadata({ params }) {
-  const country = getCountryDoc(params.countryId);
+export async function generateMetadata({ params }) {
+  const { countryId } = await params;
+  const country = getCountryDoc(countryId);
 
   if (!country) {
     return {};
@@ -35,8 +36,9 @@ export function generateMetadata({ params }) {
   };
 }
 
-export default function CountryApiPage({ params }) {
-  const country = getCountryDoc(params.countryId);
+export default async function CountryApiPage({ params }) {
+  const { countryId } = await params;
+  const country = getCountryDoc(countryId);
 
   if (!country) {
     notFound();

--- a/src/app/[countryId]/api/terms/page.jsx
+++ b/src/app/[countryId]/api/terms/page.jsx
@@ -1,0 +1,57 @@
+import { notFound } from 'next/navigation';
+import Header from '@/components/Header';
+import ApiTermsDocument from '@/components/ApiTermsDocument';
+import { getCountryDoc, SUPPORTED_COUNTRY_IDS } from '@/utils/countryDocs';
+import { getApiTermsMarkdown } from '@/utils/apiTerms';
+
+export function generateStaticParams() {
+  return SUPPORTED_COUNTRY_IDS.map((countryId) => ({ countryId }));
+}
+
+export async function generateMetadata({ params }) {
+  const { countryId } = await params;
+  const country = getCountryDoc(countryId);
+
+  if (!country) {
+    return {};
+  }
+
+  return {
+    title: 'API Terms of Service | PolicyEngine',
+    description: `Terms of service for access to the PolicyEngine API for ${country.adjective} households.`,
+    openGraph: {
+      title: 'PolicyEngine API Terms of Service',
+      description: `Terms of service for access to the PolicyEngine API for ${country.adjective} households.`,
+      url: `${country.apiUrl}/terms`,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title: 'PolicyEngine API Terms of Service',
+      description: `Terms of service for access to the PolicyEngine API for ${country.adjective} households.`,
+    },
+    alternates: {
+      canonical: `${country.apiUrl}/terms`,
+    },
+  };
+}
+
+export default async function CountryApiTermsPage({ params }) {
+  const { countryId } = await params;
+  const country = getCountryDoc(countryId);
+
+  if (!country) {
+    notFound();
+  }
+
+  return (
+    <>
+      <Header country={country} />
+      <main className="min-h-[calc(100vh-var(--pe-spacing-header))] bg-gradient-to-b from-primary-50 via-white to-bg-secondary">
+        <div className="mx-auto max-w-5xl px-6 py-12 sm:px-8 sm:py-16 lg:px-10">
+          <ApiTermsDocument markdown={getApiTermsMarkdown(countryId)} />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/components/ApiDocsContent.jsx
+++ b/src/components/ApiDocsContent.jsx
@@ -6,6 +6,7 @@ import AuthSection from './AuthSection';
 import RequestSection from './RequestSection';
 import HouseholdSection from './HouseholdSection';
 import ModelLink from './ModelLink';
+import TermsLinkSection from './TermsLinkSection';
 
 export default function ApiDocsContent({ country }) {
   const [accessMode, setAccessMode] = useState('rest');
@@ -17,6 +18,7 @@ export default function ApiDocsContent({ country }) {
       <RequestSection country={country} accessMode={accessMode} />
       <HouseholdSection country={country} accessMode={accessMode} />
       <ModelLink country={country} />
+      <TermsLinkSection country={country} />
     </>
   );
 }

--- a/src/components/ApiTermsDocument.jsx
+++ b/src/components/ApiTermsDocument.jsx
@@ -1,0 +1,214 @@
+import Link from 'next/link';
+
+function isDivider(line) {
+  return line.trim() === '---';
+}
+
+function isTopLevelHeading(line) {
+  return line.startsWith('# ');
+}
+
+function isSectionHeading(line) {
+  return line.startsWith('## ');
+}
+
+function isOrderedListItem(line) {
+  return /^\d+\.\s/.test(line.trim());
+}
+
+function renderLink(href, children, key) {
+  if (href.startsWith('/')) {
+    return (
+      <Link
+        key={key}
+        href={href}
+        className="font-medium text-primary-700 underline decoration-primary-300 underline-offset-4 transition-colors hover:text-primary-800 hover:decoration-primary-500"
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      key={key}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="font-medium text-primary-700 underline decoration-primary-300 underline-offset-4 transition-colors hover:text-primary-800 hover:decoration-primary-500"
+    >
+      {children}
+    </a>
+  );
+}
+
+function renderInlineMarkdown(text, keyPrefix) {
+  const tokenPattern = /(\*\*[^*]+\*\*|\[[^\]]+\]\([^)]+\))/g;
+  const nodes = [];
+  let cursor = 0;
+  let tokenIndex = 0;
+
+  for (const match of text.matchAll(tokenPattern)) {
+    const [token] = match;
+    const index = match.index ?? 0;
+
+    if (index > cursor) {
+      nodes.push(text.slice(cursor, index));
+    }
+
+    if (token.startsWith('**') && token.endsWith('**')) {
+      nodes.push(
+        <strong key={`${keyPrefix}-strong-${tokenIndex}`} className="font-semibold text-text-primary">
+          {token.slice(2, -2)}
+        </strong>
+      );
+    } else {
+      const [, label, href] = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/) ?? [];
+
+      if (label && href) {
+        nodes.push(renderLink(href, label, `${keyPrefix}-link-${tokenIndex}`));
+      } else {
+        nodes.push(token);
+      }
+    }
+
+    cursor = index + token.length;
+    tokenIndex += 1;
+  }
+
+  if (cursor < text.length) {
+    nodes.push(text.slice(cursor));
+  }
+
+  return nodes;
+}
+
+function renderParagraphLines(lines, keyPrefix) {
+  const children = [];
+
+  lines.forEach((line, lineIndex) => {
+    const hasHardBreak = /\s{2,}$/.test(line);
+    const content = hasHardBreak ? line.replace(/\s+$/, '') : line.trim();
+
+    children.push(...renderInlineMarkdown(content, `${keyPrefix}-${lineIndex}`));
+
+    if (lineIndex < lines.length - 1) {
+      children.push(hasHardBreak ? <br key={`${keyPrefix}-br-${lineIndex}`} /> : ' ');
+    }
+  });
+
+  return children;
+}
+
+export default function ApiTermsDocument({ markdown }) {
+  const lines = markdown.trim().split('\n');
+  const blocks = [];
+  let lineIndex = 0;
+  let blockIndex = 0;
+
+  while (lineIndex < lines.length) {
+    const line = lines[lineIndex];
+
+    if (!line.trim()) {
+      lineIndex += 1;
+      continue;
+    }
+
+    if (isDivider(line)) {
+      blocks.push(<hr key={`divider-${blockIndex}`} className="my-8 border-0 border-t border-border-light" />);
+      lineIndex += 1;
+      blockIndex += 1;
+      continue;
+    }
+
+    if (isTopLevelHeading(line)) {
+      blocks.push(
+        <h1
+          key={`h1-${blockIndex}`}
+          className="text-4xl font-bold tracking-tight text-text-primary sm:text-5xl"
+        >
+          {renderInlineMarkdown(line.slice(2), `h1-${blockIndex}`)}
+        </h1>
+      );
+      lineIndex += 1;
+      blockIndex += 1;
+      continue;
+    }
+
+    if (isSectionHeading(line)) {
+      blocks.push(
+        <h2
+          key={`h2-${blockIndex}`}
+          className="mt-10 text-2xl font-semibold tracking-tight text-text-primary sm:text-[2rem]"
+        >
+          {renderInlineMarkdown(line.slice(3), `h2-${blockIndex}`)}
+        </h2>
+      );
+      lineIndex += 1;
+      blockIndex += 1;
+      continue;
+    }
+
+    if (isOrderedListItem(line)) {
+      const items = [];
+
+      while (lineIndex < lines.length) {
+        if (isOrderedListItem(lines[lineIndex])) {
+          items.push(lines[lineIndex].trim().replace(/^\d+\.\s/, ''));
+          lineIndex += 1;
+          continue;
+        }
+
+        if (!lines[lineIndex].trim() && isOrderedListItem(lines[lineIndex + 1] ?? '')) {
+          lineIndex += 1;
+          continue;
+        }
+
+        break;
+      }
+
+      blocks.push(
+        <ol
+          key={`ol-${blockIndex}`}
+          className="mt-4 ml-5 list-decimal space-y-3 text-[1.02rem] leading-7 text-secondary-700"
+        >
+          {items.map((item, itemIndex) => (
+            <li key={`ol-${blockIndex}-${itemIndex}`} className="pl-1">
+              {renderInlineMarkdown(item, `ol-${blockIndex}-${itemIndex}`)}
+            </li>
+          ))}
+        </ol>
+      );
+      blockIndex += 1;
+      continue;
+    }
+
+    const paragraphLines = [line];
+    lineIndex += 1;
+
+    while (
+      lineIndex < lines.length &&
+      lines[lineIndex].trim() &&
+      !isDivider(lines[lineIndex]) &&
+      !isTopLevelHeading(lines[lineIndex]) &&
+      !isSectionHeading(lines[lineIndex]) &&
+      !isOrderedListItem(lines[lineIndex])
+    ) {
+      paragraphLines.push(lines[lineIndex]);
+      lineIndex += 1;
+    }
+
+    blocks.push(
+      <p key={`p-${blockIndex}`} className="mt-4 text-[1.02rem] leading-7 text-secondary-700">
+        {renderParagraphLines(paragraphLines, `p-${blockIndex}`)}
+      </p>
+    );
+    blockIndex += 1;
+  }
+
+  return (
+    <article className="rounded-[2rem] border border-border-light bg-white px-6 py-8 shadow-[0_20px_60px_rgba(15,23,42,0.08)] sm:px-10 sm:py-12 lg:px-14">
+      {blocks}
+    </article>
+  );
+}

--- a/src/components/TermsLinkSection.jsx
+++ b/src/components/TermsLinkSection.jsx
@@ -1,0 +1,21 @@
+'use client';
+
+export default function TermsLinkSection({ country }) {
+  return (
+    <section className="py-16 bg-bg-secondary">
+      <div className="max-w-4xl mx-auto px-6 text-center">
+        <h2 className="text-3xl font-bold text-text-primary mb-6">API terms and conditions</h2>
+        <p className="text-text-secondary mb-8 text-lg max-w-2xl mx-auto">
+          Review the terms that govern access to the PolicyEngine API before requesting credentials,
+          integrating the hosted endpoint, or self-hosting the same interface.
+        </p>
+        <a
+          href={`/${country.id}/api/terms`}
+          className="inline-flex items-center justify-center rounded-lg border-2 border-primary-500 bg-primary-500 px-5 py-4 text-lg font-semibold text-white transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-600 hover:bg-primary-600"
+        >
+          Read API terms and conditions →
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/utils/apiTerms.js
+++ b/src/utils/apiTerms.js
@@ -1,0 +1,163 @@
+const API_TERMS_TEMPLATE = `# PolicyEngine API Terms of Service
+
+These PolicyEngine API Terms of Service ("**Terms**") form a binding agreement between PolicyEngine, Inc. ("**PolicyEngine," "we," "us," or "our"**) and the entity or person agreeing to them ("**Customer," "you," or "your"**) that accesses or uses the PolicyEngine application‑programming interface, endpoints, documentation, and any related services (collectively, the "**API**"). **By requesting API credentials, making an API call, or otherwise using the API, you accept these Terms.**
+
+---
+
+## 1. Definitions
+
+**"AGPL"** means the GNU Affero General Public License v3.0.  
+**"Household Scenario"** means data describing a hypothetical or de‑identified household, such as age bands, income ranges, and geographic codes that cannot reasonably be linked to an identified or identifiable person.  
+**"Output"** means the JSON or other results returned by the API in response to a request.  
+**"Request Data"** means the payload, headers, and metadata you submit to the API.  
+**"Service Level Credits"** means the fee credits defined in Section 8.  
+**"Usage Logs"** means system logs that include Request Data or Output and related metadata.
+
+---
+
+## 2. API License and Access
+
+1. **Limited License.** Subject to these Terms, PolicyEngine grants you a non‑exclusive, non‑transferable, revocable license to access and use the API solely to build or operate software or services that compute or analyze public‑policy outcomes.
+
+2. **API Keys.** You agree to keep your API credentials confidential and may not share them except with agents acting on your behalf under written confidentiality obligations.
+
+3. **Acceptable Use.** You will not (a) submit malware, unlawful content, or personal data that identifies a natural person; (b) attempt to reverse‑engineer, scrape, or violate rate limits; (c) use the API to provide legal or tax advice without appropriate professional oversight; or (d) misrepresent Output as official government guidance.
+
+---
+
+## 3. Customer Data
+
+1. **No PII Submission.** You shall not submit names, full street addresses, Social Security numbers, or other direct identifiers. If you inadvertently submit personal data, you must notify us promptly and cooperate in deletion.
+
+2. **Representation.** You represent that Request Data consists of (i) Household Scenarios **or** (ii) information you are lawfully authorized to process and share with PolicyEngine.
+
+3. **Ownership.** You retain all rights in Request Data and Output, except that you grant PolicyEngine a worldwide, royalty‑free license to process Request Data and Output to provide the API and improve our microsimulation models.
+
+---
+
+## 4. Data Handling & Anonymisation
+
+PolicyEngine logs request and response data solely for speed of execution (caching), abuse‑detection, debugging, billing, and statistical research to improve its microsimulation models. Logs are never sold, shared with third parties (except subprocessors under equivalent obligations), or used to train public machine‑learning models.
+
+## 5. Open‑Source Components
+
+1. **Python Package.** Our reference Python implementation is licensed under the AGPL. API use does **not** trigger AGPL source‑code disclosure, but running or distributing the package yourself does.
+
+2. **Priority of Terms.** In case of conflict, these API Terms govern your API access; the AGPL governs your use of our open‑source code.
+
+---
+
+## 6. Intellectual‑Property Rights
+
+1. **PolicyEngine IP.** Aside from the limited license in Section 2, PolicyEngine retains all rights in the API, documentation, and underlying models.
+
+2. **Feedback.** You grant PolicyEngine a perpetual, irrevocable, royalty‑free license to use any feedback you provide to improve the API.
+
+---
+
+## 7. Rate Limits; Fair Use
+
+We may impose request‑per‑minute or daily volume limits, published in the dashboard or documentation. Excess use may result in temporary throttling or suspension without liability.
+
+---
+
+## 8. Service Levels & Support
+
+1. **Uptime Commitment.** We target **99% monthly API availability**. If availability drops below 99%, you may request Service Level Credits equal to 10% of that month's fees.
+
+2. **Planned Maintenance.** We will give at least 24 hours' notice for planned downtime exceeding 15 minutes.
+
+3. **Support.** Standard e‑mail support (support@policyengine.org) is included. Contact [support@policyengine.org](mailto:support@policyengine.org) for enterprise support.
+
+---
+
+## 9. Security & Privacy
+
+We maintain administrative, technical, and physical safeguards designed to protect Request Data. Details appear in our [Privacy Policy]({{privacyLink}}), which is incorporated by reference.
+
+---
+
+## 10. Confidentiality
+
+Each party will protect the other's non‑public information with the same care it uses for its own, but at least reasonable care, and will use it only to exercise rights and fulfil obligations under these Terms.
+
+---
+
+## 11. Term & Termination
+
+1. **Term.** These Terms start when you first use the API and continue until terminated.
+
+2. **Termination for Convenience.** Either party may terminate at any time on 30 days' written notice.
+
+3. **Termination for Cause.** Either party may terminate immediately if the other materially breaches these Terms and fails to cure within 15 days of notice.
+
+4. **Effect.** Upon termination you must cease API calls. Sections 4 (aggregated logs), 5, 6, 10, 12–17 survive.
+
+---
+
+## 12. Disclaimers
+
+THE API AND OUTPUT ARE PROVIDED **"AS IS"**. POLICYENGINE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON‑INFRINGEMENT. OUTPUT IS **ILLUSTRATIVE ONLY** AND NOT LEGAL, TAX, OR FINANCIAL ADVICE.
+
+---
+
+## 13. Limitation of Liability
+
+1. **Indirect Damages.** POLICYENGINE WILL NOT BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES, OR LOSS OF PROFITS OR DATA, EVEN IF ADVISED OF THE POSSIBILITY.
+
+2. **Cap.** POLICYENGINE'S TOTAL LIABILITY WILL NOT EXCEED THE FEES PAID BY CUSTOMER IN THE 12 MONTHS PRECEDING THE EVENT GIVING RISE TO THE CLAIM.
+
+---
+
+## 14. Indemnification
+
+You will defend, indemnify, and hold harmless PolicyEngine from any third‑party claim arising from your (a) misuse of the API, (b) violation of these Terms, or (c) infringement of intellectual‑property or privacy rights.
+
+---
+
+## 15. Modifications to the API or Terms
+
+We may modify these Terms or the API by posting an updated version or sending notice to your account e‑mail. Changes take effect 30 days after notice. Continued use constitutes acceptance.
+
+---
+
+## 16. Governing Law; Dispute Resolution
+
+These Terms are governed by the laws of {{jurisdiction}}, excluding its conflict of law rules. The parties will resolve disputes exclusively in the federal or state courts located in {{courtLocation}}, and consent to personal jurisdiction there.
+
+---
+
+## 17. Assignment; Entire Agreement
+
+You may not assign these Terms without PolicyEngine's prior written consent. These Terms, any Order Form, and the documents linked herein constitute the entire agreement and supersede all prior agreements regarding their subject.
+
+---
+
+## 18. Contact
+
+Questions may be directed to **legal@policyengine.org**
+
+---
+
+**By using the API you acknowledge that you have read, understood, and agree to be bound by these Terms.**`;
+
+const DEFAULT_TERMS_CONTEXT = {
+  jurisdiction: 'the United States',
+  courtLocation: 'Washington, DC',
+};
+
+const TERMS_CONTEXT_BY_COUNTRY = {
+  uk: {
+    jurisdiction: 'the United Kingdom',
+    courtLocation: 'London',
+  },
+  us: DEFAULT_TERMS_CONTEXT,
+};
+
+export function getApiTermsMarkdown(countryId) {
+  const context = TERMS_CONTEXT_BY_COUNTRY[countryId] ?? DEFAULT_TERMS_CONTEXT;
+
+  return API_TERMS_TEMPLATE.replaceAll('{{jurisdiction}}', context.jurisdiction)
+    .replaceAll('{{courtLocation}}', context.courtLocation)
+    .replaceAll('{{privacyLink}}', `/${countryId}/privacy`);
+}


### PR DESCRIPTION
Fixes #10

## Summary
- add `/[countryId]/api/terms` pages with the legacy API terms copy rendered in the docs app style
- add a bottom-of-page terms and conditions link section to the main API docs page
- make `assetPrefix` production-only and update dynamic route params usage for the current Next.js behavior

## Testing
- npm run build