### PR TITLE
Disable asset prefix during next dev

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
+const isDev = process.env.NODE_ENV === 'development';
+const assetPrefix = isDev ? undefined : '/_zones/household-api-docs';
+
 const nextConfig = {
   output: 'export',
-  assetPrefix: '/_zones/household-api-docs',
+  ...(assetPrefix ? { assetPrefix } : {}),
   images: {
     unoptimized: true,
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  assetPrefix: '/_zones/household-api-docs',
   images: {
     unoptimized: true,
   },

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
     { "source": "/:countryId/api", "destination": "/:countryId/api/", "statusCode": 308 }
   ],
   "rewrites": [
+    { "source": "/_zones/household-api-docs/_next/:path*", "destination": "/_next/:path*" },
     { "source": "/:countryId/api/_next/:path*", "destination": "/_next/:path*" }
   ]
 }


### PR DESCRIPTION
## Summary
- only apply the /_zones/household-api-docs assetPrefix outside local next dev
- keep production multizone asset routing unchanged

## Verification
- bun run build
