### PR TITLE
Document 422 unsupported version value responses

### DIFF
--- a/src/utils/countryDocs.js
+++ b/src/utils/countryDocs.js
@@ -2851,13 +2851,6 @@ export function getCalculateResponseExamples(country) {
       }),
     },
     {
-      id: '422-unsupported-version',
-      status: '422',
-      label: 'Unsupported version selector',
-      title: '422 unsupported version selector',
-      code: getCalculateVersionRoutingErrorExample(country),
-    },
-    {
       id: '401-invalid-token',
       status: '401',
       label: 'Missing or invalid auth token',
@@ -2877,6 +2870,13 @@ export function getCalculateResponseExamples(country) {
         status: 'error',
         message: 'Country zz not found. Available countries are: uk, us, ca, ng, il',
       }),
+    },
+    {
+      id: '422-unsupported-version',
+      status: '422',
+      label: 'Unsupported version selector',
+      title: '422 unsupported version selector',
+      code: getCalculateVersionRoutingErrorExample(country),
     },
     {
       id: '500-calculation-failed',

--- a/src/utils/countryDocs.js
+++ b/src/utils/countryDocs.js
@@ -2656,11 +2656,12 @@ export function getCalculateRequestExamples(country) {
       title: 'version',
       type: 'string',
       description:
-        'Hosted gateway routing key. The only accepted values are current, frontier, or an exact numerical version string.',
+        'Hosted gateway routing key. The only accepted values are current, frontier, or an exact active country package version string.',
       notes: [
         'Use `current` for the stable deployed model.',
         'Use `frontier` for the next deployed model.',
         `Use an exact numerical version string, such as \`${getExampleModelVersion(country)}\`, to route to that deployed version directly.`,
+        'Inactive or unrecognized exact version strings return a 422 `unsupported_version` response.',
         'Self-hosted Docker calls can omit this key.',
       ],
       code: formatJson({
@@ -2749,6 +2750,10 @@ function getExampleModelVersion(country) {
   return country.exampleModelVersion ?? (country.id === 'uk' ? '2.88.18' : '1.732.0');
 }
 
+function getExampleFrontierModelVersion(country) {
+  return country.exampleFrontierModelVersion ?? (country.id === 'uk' ? '2.88.19' : '1.733.0');
+}
+
 export function getCalculateSuccessResponseExample(country) {
   const target = getPrimaryRequestResult(country);
 
@@ -2804,6 +2809,20 @@ export function getCalculateValidationErrorExample(country) {
   });
 }
 
+export function getCalculateVersionRoutingErrorExample(country) {
+  return formatJson({
+    status: 'error',
+    code: 'unsupported_version',
+    message: `No active household API app serves \`${country.id}\` package version \`0.0.0\``,
+    requested_version: '0.0.0',
+    country_id: country.id,
+    available_versions: {
+      current: getExampleModelVersion(country),
+      frontier: getExampleFrontierModelVersion(country),
+    },
+  });
+}
+
 export function getCalculateResponseExamples(country) {
   const examples = [
     {
@@ -2830,6 +2849,13 @@ export function getCalculateResponseExamples(country) {
         message:
           'Invalid period key `2026-13` for `employment_income` on `people/you`. Expected a year (e.g. "2026") or a month (e.g. "2026-01").',
       }),
+    },
+    {
+      id: '422-unsupported-version',
+      status: '422',
+      label: 'Unsupported version selector',
+      title: '422 unsupported version selector',
+      code: getCalculateVersionRoutingErrorExample(country),
     },
     {
       id: '401-invalid-token',

--- a/src/utils/countryDocs.js
+++ b/src/utils/countryDocs.js
@@ -2874,8 +2874,8 @@ export function getCalculateResponseExamples(country) {
     {
       id: '422-unsupported-version',
       status: '422',
-      label: 'Unsupported version selector',
-      title: '422 unsupported version selector',
+      label: 'Unsupported version value',
+      title: '422 unsupported version value',
       code: getCalculateVersionRoutingErrorExample(country),
     },
     {


### PR DESCRIPTION
Fixes #22

## Summary
- Documents that hosted API `version` values must be `current`, `frontier`, or an exact active country package version.
- Adds the `422 unsupported_version` response example for inactive or unrecognized exact version values.
- Shows `requested_version`, `country_id`, and `available_versions` in the response body.
- Sorts endpoint response examples numerically, placing 422 after 404 and before 500.

## Dependency
This docs PR depends on PolicyEngine/policyengine-household-api#1571. Merge that household API PR first so the documented behavior exists in the API before the docs are published.

## Validation
- `npm run build`